### PR TITLE
Create LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,6 @@
+GMapCatcher
+
+© 2008 the GMapCatcher team (for full list of authors see: gmapcatcher/widgets/widCredits.py)
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation:
+https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html


### PR DESCRIPTION
Add LICENSE file clarifying that GMapCatcher code is licensed under GPLv2