### PR TITLE
Added --map-server and --repo-type to download.py

### DIFF
--- a/download.py
+++ b/download.py
@@ -37,7 +37,7 @@ def download_coordpath(downloader, args, mConf):
         downloader.query_coordpath(coords, zl, args.width, args.layer, dl_callback, conf=mConf)
         downloader.wait_all()
 
-def get_args(sys_argv):
+def get_args(sys_argv, ctx_map):
     args = MapArgs(sys_argv)
     if (args.location is None) and (args.gpx is None) and ((args.lat is None) or (args.lng is None)):
         args.print_help()
@@ -49,7 +49,7 @@ def get_args(sys_argv):
         if (not args.location in locations.keys()):
             args.location = ctx_map.search_location(args.location)
             if (args.location[:6] == "error="):
-                print args.location[6:]
+                print(args.location[6:])
                 sys.exit(0)
 
         coord = ctx_map.get_locations()[args.location]
@@ -69,28 +69,31 @@ def get_args(sys_argv):
     return args
 
 if __name__ == "__main__":
-    args = get_args(sys.argv)
+    mConf = MapConf()
+    ## Here we can overwrite some of the config values
+    # print mConf.map_service
+    # print mConf.repository_type
+    ctx_map = MapServ(mConf)
+    args = get_args(sys.argv, ctx_map)
+    mConf.map_service = args.map_server
+    mConf.repository_type = args.repo_type
+    ctx_map = MapServ(mConf)
 
     if (args.location is None):
         args.location = "somewhere"
     else:
-        print "location = %s" % args.location
+        print("location = %s" % args.location)
 
     if args.gpx is None:
-        print "Download %s (%f, %f), range (%f, %f), mapsource: \"%s %s\", zoom level: %d to %d" % \
+        print("Download %s (%f, %f), range (%f, %f), mapsource: \"%s %s\", zoom level: %d to %d" % \
                 (args.location, args.lat, args.lng,
                  args.lat_range, args.lng_range,
                  '', '',
-                 args.max_zl, args.min_zl)
+                 args.max_zl, args.min_zl))
     else:
-        print "Download path in %s, mapsource: \"%s %s\", zoom level: %d to %d, width=%d tiles" % \
-                (args.gpx, '', '', args.max_zl, args.min_zl, args.width)
+        print("Download path in %s, mapsource: \"%s %s\", zoom level: %d to %d, width=%d tiles" % \
+              (args.gpx, '', '', args.max_zl, args.min_zl, args.width))
 
-    mConf = MapConf()
-    ## Here we can overwrite some of the config values
-    # print mConf.map_service
-    # print mConf.repository_type    
-    ctx_map = MapServ(mConf)
     downloader = MapDownloader(ctx_map, args.nr_threads)
     try:
         if args.gpx is not None:
@@ -98,6 +101,6 @@ if __name__ == "__main__":
         else:
             download(downloader, args, mConf)
     finally:
-        print "\nDownload Complete!"
+        print("\nDownload Complete!")
         downloader.stop_all()
         os.kill(os.getpid(), signal.SIGTERM)

--- a/gmapcatcher/mapArgs.py
+++ b/gmapcatcher/mapArgs.py
@@ -17,6 +17,8 @@ class MapArgs():
     layer = LAYER_MAP
     width = -1
     height = -1
+    map_server = VIRTUAL_EARTH
+    repo_type = REPOS_TYPE_OSM
 
     def print_help(self):
         print ' '
@@ -33,6 +35,9 @@ class MapArgs():
         print '  --terrain     Retrieve terrain images'
         print '  --hybrid      Retrieve hybrid images'
         print '  --chart       Retrieve chart images'
+        print '  --map-server= Name of map server to use (default = {})'.format(MAP_SERVERS[self.map_server])
+        print '  --repo-type=  Name of repo type to save files as (default = {})'.format(REPOS_TYPE[self.repo_type])
+
         print ' '
         print '  --latrange=   Latitude Range to get    (default = %f)' % self.lat_range
         print '  --lngrange=   Longitude Range to get   (default = %f)' % self.lng_range
@@ -100,7 +105,15 @@ class MapArgs():
                         self.lat = 0
                         self.lat_range = 85
                         self.lng_range = 179
-
+                    elif arg.startswith('--map-server='):
+                        self.map_server = oarg[13:]
+                        print("map server = {}".format(self.map_server))
+                        print("map server idx = {}".format(MAP_SERVERS.index(self.map_server)))
+                    elif arg.startswith('--repo-type='):
+                        rt = oarg[12:]
+                        print("repo type = {}".format(rt))
+                        self.repo_type = REPOS_TYPE.index(rt)
+                        print("repo type idx = {}".format(self.repo_type))
     def __str__(self):
         return ("download.py --max-zoom=%s --min-zoom=%s" +
                 " --latitude=%s --longitude=%s" +

--- a/gmapcatcher/mapConf.py
+++ b/gmapcatcher/mapConf.py
@@ -172,7 +172,7 @@ class MapConf():
         ## Show a small cross in the center of the map, default is False (0)
         self.show_cross = read_config('show_cross', 0, int, SECTION_MAP)
         ## Map service to get images, default is Nokia
-        self.map_service = read_config('map_service', MAP_SERVERS[NOKIA], str, SECTION_MAP)
+        self.map_service = read_config('map_service', MAP_SERVERS[VIRTUAL_EARTH], str, SECTION_MAP)
         ## Google API key
         self.google_API = read_config('google_API', 'AIzaSyB3d6ZZvE0msnWbh9gX3bAN0bSFf4m8DuE', str, SECTION_MAP)
         ## cloudMade API key


### PR DESCRIPTION
Previously `download.py` couldn't pick the map server or the saved repo type.

This PR adds those features as CLI flags.